### PR TITLE
Update cox_preflight_VE.R

### DIFF
--- a/analysis/VE/cox_preflight_VE.R
+++ b/analysis/VE/cox_preflight_VE.R
@@ -515,7 +515,8 @@ if (db == "unmatched") {
       bind_cols(
         lapply(
           vars2_cat, 
-          function(x) data_cox_strata_keep %>% merge_levels(var = x, strata = TRUE)
+          # set strata=FALSE so that vars0="timesincevax_pw" not included in grouping vars
+          function(x) data_cox_strata_keep %>% merge_levels(var = x, strata = FALSE)
         )
       )
     logoutput(merge_summary(data_cox_strata_merged))


### PR DESCRIPTION
Remove grouping by `timesincevax_pw` in `merge_levels` as discussed.

Turns out this is just changing the `strata` argument in `merge_levels`. Ignore [this closed PR](https://github.com/opensafely/ckd-coverage-ve/pull/7) where I had overcomplicated it.